### PR TITLE
update license to apache 2.0

### DIFF
--- a/bootstrap/eksctl/crossplane/aws-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/aws-provider-config.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig

--- a/bootstrap/eksctl/crossplane/aws-provider.yaml
+++ b/bootstrap/eksctl/crossplane/aws-provider.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/bootstrap/eksctl/crossplane/jet-aws-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/jet-aws-provider-config.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: aws.jet.crossplane.io/v1alpha1
 kind: ProviderConfig

--- a/bootstrap/eksctl/crossplane/jet-aws-provider.yaml
+++ b/bootstrap/eksctl/crossplane/jet-aws-provider.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/bootstrap/eksctl/crossplane/kubernetes-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/kubernetes-provider-config.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: kubernetes.crossplane.io/v1alpha1
 kind: ProviderConfig

--- a/bootstrap/eksctl/crossplane/kubernetes-provider.yaml
+++ b/bootstrap/eksctl/crossplane/kubernetes-provider.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/bootstrap/eksctl/eksctl-fargate.yaml
+++ b/bootstrap/eksctl/eksctl-fargate.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig

--- a/bootstrap/eksctl/eksctl.yaml
+++ b/bootstrap/eksctl/eksctl.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig

--- a/bootstrap/terraform/crossplane-providers/kubernetes-provider.yaml
+++ b/bootstrap/terraform/crossplane-providers/kubernetes-provider.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: pkg.crossplane.io/v1
 kind: Provider

--- a/bootstrap/terraform/karpenter-provisioners/default-provisioner.yaml
+++ b/bootstrap/terraform/karpenter-provisioners/default-provisioner.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 data "aws_availability_zones" "available" {}
 

--- a/bootstrap/terraform/variables.tf
+++ b/bootstrap/terraform/variables.tf
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 variable "region" {
   description = "AWS region"

--- a/compositions/aws-provider/cloudfront/definition.yaml
+++ b/compositions/aws-provider/cloudfront/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/cloudfront/s3-origin-oai.yaml
+++ b/compositions/aws-provider/cloudfront/s3-origin-oai.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/dynamodb/definition.yaml
+++ b/compositions/aws-provider/dynamodb/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/dynamodb/on-demand-composite-key.yaml
+++ b/compositions/aws-provider/dynamodb/on-demand-composite-key.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/dynamodb/on-demand-partition-key.yaml
+++ b/compositions/aws-provider/dynamodb/on-demand-partition-key.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/dynamodb/provisioned-composite-gsi.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-gsi.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/dynamodb/provisioned-composite-key.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-key.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/dynamodb/provisioned-composite-lsi.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-lsi.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/elasticache-redis/definition.yaml
+++ b/compositions/aws-provider/elasticache-redis/definition.yaml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/example-application/definition.yaml
+++ b/compositions/aws-provider/example-application/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/example-application/example-application.yaml
+++ b/compositions/aws-provider/example-application/example-application.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/iam-policy/definition.yaml
+++ b/compositions/aws-provider/iam-policy/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/iam-policy/dynamodb-manage-table.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-manage-table.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/iam-policy/dynamodb-read.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-read.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/iam-policy/dynamodb-write.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-write.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/irsa/definition.yaml
+++ b/compositions/aws-provider/irsa/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/irsa/irsa-exact.yaml
+++ b/compositions/aws-provider/irsa/irsa-exact.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/rds/definition.yaml
+++ b/compositions/aws-provider/rds/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/rds/postgres-aurora.yaml
+++ b/compositions/aws-provider/rds/postgres-aurora.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/rds/rds-postgres.yaml
+++ b/compositions/aws-provider/rds/rds-postgres.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/s3/definition.yaml
+++ b/compositions/aws-provider/s3/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/s3/general-purpose.yaml
+++ b/compositions/aws-provider/s3/general-purpose.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/s3/multi-tenant.yaml
+++ b/compositions/aws-provider/s3/multi-tenant.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/vpc-subnets/definition.yaml
+++ b/compositions/aws-provider/vpc-subnets/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition-networkid.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc-subnets/vpc-composition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/aws-provider/vpc/definition.yaml
+++ b/compositions/aws-provider/vpc/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/aws-provider/vpc/vpc-composition.yaml
+++ b/compositions/aws-provider/vpc/vpc-composition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/terrajet-aws-provider/eks/eks-cluster.yaml
+++ b/compositions/terrajet-aws-provider/eks/eks-cluster.yaml
@@ -1,4 +1,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # TODO Work in Progress

--- a/compositions/terrajet-aws-provider/lambda/container.yaml
+++ b/compositions/terrajet-aws-provider/lambda/container.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/terrajet-aws-provider/lambda/definitions.yaml
+++ b/compositions/terrajet-aws-provider/lambda/definitions.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/terrajet-aws-provider/lambda/zip.yaml
+++ b/compositions/terrajet-aws-provider/lambda/zip.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/terrajet-aws-provider/s3/definition.yaml
+++ b/compositions/terrajet-aws-provider/s3/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition

--- a/compositions/terrajet-aws-provider/s3/s3-composition.yaml
+++ b/compositions/terrajet-aws-provider/s3/s3-composition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition

--- a/compositions/terrajet-aws-provider/vpc/definition.yaml
+++ b/compositions/terrajet-aws-provider/vpc/definition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 ---
 apiVersion: apiextensions.crossplane.io/v1

--- a/compositions/terrajet-aws-provider/vpc/vpc-composition.yaml
+++ b/compositions/terrajet-aws-provider/vpc/vpc-composition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 ---
 apiVersion: apiextensions.crossplane.io/v1

--- a/examples/aws-provider/composite-resources/cloudfront/oai-s3.yaml
+++ b/examples/aws-provider/composite-resources/cloudfront/oai-s3.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: CDN

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: DynamoDBTable

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: DynamoDBTable

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: DynamoDBTable

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: DynamoDBTable

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: DynamoDBTable

--- a/examples/aws-provider/composite-resources/eks/eks-claim.yaml
+++ b/examples/aws-provider/composite-resources/eks/eks-claim.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 #----------------------------------------------------------------------------------
 # Steps to Deploy:

--- a/examples/aws-provider/composite-resources/example-application/example-application.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: ExampleApp

--- a/examples/aws-provider/composite-resources/iam/iam-dynamodb-read.yaml
+++ b/examples/aws-provider/composite-resources/iam/iam-dynamodb-read.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: IAMPolicy

--- a/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Update spec.subnetIds and spec.vpcId fields before use.
 # The Kubernetes secret below is used to create the master user password for RDS. Unfortunately, auto generated passwords are not supported by RDS cluster yet.

--- a/examples/aws-provider/composite-resources/rds/postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/postgres.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Update spec.subnetIds and spec.vpcId fields before use.
 # Run `kubectl apply -f postgres.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider

--- a/examples/aws-provider/composite-resources/s3/general-purpose.yaml
+++ b/examples/aws-provider/composite-resources/s3/general-purpose.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
 kind: ObjectStorage

--- a/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f vpc-subnets-claim.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
 

--- a/examples/aws-provider/composite-resources/vpc/vpc.yaml
+++ b/examples/aws-provider/composite-resources/vpc/vpc.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f vpc.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
 ---

--- a/examples/aws-provider/managed-resources/vpc.yaml
+++ b/examples/aws-provider/managed-resources/vpc.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f vpc.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and AWS Provider
 ---

--- a/examples/terrajet-aws-provider/composite-resources/s3.yaml
+++ b/examples/terrajet-aws-provider/composite-resources/s3.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 #  Composition and Definition path -> compositions/terrajet-aws-provider/s3
 #  This composition creates KMS key and applies to S3 bucket by default

--- a/examples/terrajet-aws-provider/composite-resources/vpc.yaml
+++ b/examples/terrajet-aws-provider/composite-resources/vpc.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f vpc.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and Terrajet AWS Provider
 ---

--- a/examples/terrajet-aws-provider/managed-resources/kms.yaml
+++ b/examples/terrajet-aws-provider/managed-resources/kms.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f kms.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and Terrajet AWS Provider
 ---

--- a/examples/terrajet-aws-provider/managed-resources/s3.yaml
+++ b/examples/terrajet-aws-provider/managed-resources/s3.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f s3.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and Terrajet AWS Provider
 ---

--- a/examples/terrajet-aws-provider/managed-resources/vpc.yaml
+++ b/examples/terrajet-aws-provider/managed-resources/vpc.yaml
@@ -1,5 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: Apache-2.0
 
 # Run `kubectl apply -f vpc.yaml` to test this example once you bootstrap the EKS cluster with Crossplane and Terrajet AWS Provider
 ---


### PR DESCRIPTION
### What does this PR do?

Changes file header license type to Apache 2.0


### Motivation

This repository's license type has changed recently.


### More

Command used: 
```bash
for i in `grep SPDX . -r -l`; do sed -i '' "s/MIT-0/Apache-2\.0/g" ${i} ; done
```

