### PR TITLE
update eksctl crossplane version

### DIFF
--- a/bootstrap/eksctl/README.md
+++ b/bootstrap/eksctl/README.md
@@ -115,7 +115,7 @@ kubectl create namespace crossplane-system
 helm repo add crossplane-stable https://charts.crossplane.io/stable
 helm repo update
 
-helm install crossplane --namespace crossplane-system --version 1.9.0 crossplane-stable/crossplane
+helm install crossplane --namespace crossplane-system --version 1.10.1 crossplane-stable/crossplane
 ```
 
 ```bash


### PR DESCRIPTION
### What does this PR do?

Update the Crossplane version to 1.10.1. 


### Motivation

This package requires Crossplane version above 1.9.0 and thus does not work.  https://github.com/awslabs/crossplane-on-eks/blob/90a2561468bdf9755fe2f4b9dcaa61295d40c647/compositions/aws-provider/crossplane.yaml#L14


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
