### PR TITLE
add upbound aws provider 

### DIFF
--- a/bootstrap/eksctl/crossplane/upbound-aws-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/upbound-aws-provider-config.yaml
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: aws-provider-config
+spec:
+  credentials:
+    source: IRSA

--- a/bootstrap/eksctl/crossplane/upbound-aws-provider.yaml
+++ b/bootstrap/eksctl/crossplane/upbound-aws-provider.yaml
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws
+spec:
+  package: "xpkg.upbound.io/upbound/provider-aws:v0.20.0"
+  controllerConfigRef:
+    name: upbound-provider-aws
+---
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: upbound-provider-aws
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/crossplane-provider-aws # Enter your IAM Role ARN
+
+spec:
+  podSecurityContext:
+    fsGroup: 2000 # This is needed for IRSA.
+  args:
+      - --debug


### PR DESCRIPTION
### What does this PR do?

Adds configurations for the Upbound AWS provider. 


### Motivation

terrajet is being deprecated and we need to move to the Upbound providers.


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
