### PR TITLE
Add s3 object read and write policies

### DIFF
--- a/compositions/aws-provider/iam-policy/definition.yaml
+++ b/compositions/aws-provider/iam-policy/definition.yaml
@@ -23,6 +23,8 @@ spec:
               properties:
                 resourceArn:
                   type: string
+                roleName:
+                  type: string
                 resourceConfig:
                   description: ResourceConfig defines general properties of this AWS
                     resource.

--- a/compositions/aws-provider/iam-policy/s3-read.yaml
+++ b/compositions/aws-provider/iam-policy/s3-read.yaml
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: read-s3.iampolicy.awsblueprints.io
+  labels:
+    iam.awsblueprints.io/policy-type: read
+    iam.awsblueprints.io/service: s3-bucket
+    iam.awsblueprints.io/attach-policy: "true"
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: awsblueprints.io/v1alpha1
+    kind: IAMPolicy
+  patchSets:
+    - name: common-fields
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            mergeOptions:
+              appendSlice: true
+              keepMapValues: true
+  resources:
+    - name: read-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Policy
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            name: ""
+            document: ""
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: status.policyArn
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.name
+          combine:
+            variables:
+              - fromFieldPath: metadata.name
+            strategy: string
+            string:
+              fmt: "%s-s3-bucket-read"
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.document
+          combine:
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+            strategy: string
+            string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Action": [
+                        "s3:GetObject",
+                        "s3:ListBucket",
+                        "s3:GetBucketLocation",
+                        "s3:GetObjectVersion",
+                        "s3:GetLifecycleConfiguration"
+                      ],
+                      "Resource": [
+                        "%s",
+                        "%s/*"
+                      ]
+                    }
+                  ]
+                }
+    - name: policy-attachment
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            policyArnSelector:
+              matchControllerRef: true
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.roleName
+          toFieldPath: spec.forProvider.roleName
+          policy:
+            fromFieldPath: Required

--- a/compositions/aws-provider/iam-policy/s3-write.yaml
+++ b/compositions/aws-provider/iam-policy/s3-write.yaml
@@ -1,0 +1,103 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: write-s3.iampolicy.awsblueprints.io
+  labels:
+    iam.awsblueprints.io/policy-type: write
+    iam.awsblueprints.io/service: s3-bucket
+    iam.awsblueprints.io/attach-policy: "true"
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: awsblueprints.io/v1alpha1
+    kind: IAMPolicy
+  patchSets:
+    - name: common-fields
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.deletionPolicy
+          toFieldPath: spec.deletionPolicy
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.name
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            mergeOptions:
+              appendSlice: true
+              keepMapValues: true
+  resources:
+    - name: write-policy
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: Policy
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            name: ""
+            document: ""
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          toFieldPath: status.policyArn
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.name
+          combine:
+            variables:
+              - fromFieldPath: metadata.name
+            strategy: string
+            string:
+              fmt: "%s-s3-bucket-write"
+        - type: CombineFromComposite
+          toFieldPath: spec.forProvider.document
+          combine:
+            variables:
+            - fromFieldPath: spec.resourceArn
+            - fromFieldPath: spec.resourceArn
+            strategy: string
+            string:
+              fmt: |
+                {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                    {
+                      "Effect": "Allow",
+                      "Action": [
+                        "s3:PutObject",
+                        "s3:PutObjectAcl",
+                        "s3:PutLifecycleConfiguration",
+                        "s3:DeleteObject"
+                      ],
+                      "Resource": [
+                        "%s",
+                        "%s/*"
+                      ]
+                    }
+                  ]
+                }
+    - name: policy-attachment
+      base:
+        apiVersion: iam.aws.crossplane.io/v1beta1
+        kind: RolePolicyAttachment
+        spec:
+          deletionPolicy: Delete
+          forProvider:
+            policyArnSelector:
+              matchControllerRef: true
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.roleName
+          toFieldPath: spec.forProvider.roleName
+          policy:
+            fromFieldPath: Required


### PR DESCRIPTION
### What does this PR do?

Adds IAM policy templates for read and write S3 objects


### Motivation

Access to S3 objects are common. We need to define one for reference by our customers.


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
