### PR TITLE
split composite example into db and app

### DIFF
--- a/compositions/aws-provider/example-application/definition.yaml
+++ b/compositions/aws-provider/example-application/definition.yaml
@@ -4,15 +4,15 @@
 apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
-  name: xexampleapps.awsblueprints.io
+  name: xdynamodbexamples.awsblueprints.io
 spec:
   group: awsblueprints.io
   names:
-    kind: XExampleApp
-    plural: xexampleapps
+    kind: XDynamoDBExample
+    plural: xdynamodbexamples
   claimNames:
-    kind: ExampleApp
-    plural: exampleapps
+    kind: DynamoDBExample
+    plural: dynamodbexamples
   connectionSecretKeys:
     - region
     - tableName

--- a/compositions/aws-provider/example-application/example-application.yaml
+++ b/compositions/aws-provider/example-application/example-application.yaml
@@ -11,7 +11,7 @@ spec:
   writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
-    kind: XExampleApp
+    kind: XDynamoDBExample
   patchSets:
     - name: common-fields
       patches:
@@ -122,53 +122,3 @@ spec:
           toFieldPath: spec.policyArns[0]
         - fromFieldPath: status.writePolicyArn
           toFieldPath: spec.policyArns[1]
-    - name: example-app
-      base:
-        apiVersion: kubernetes.crossplane.io/v1alpha1
-        kind: Object
-        spec:
-          forProvider:
-            manifest:
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: example-app
-                namespace: ""
-                labels:
-                  app: dynamodb-table-test
-              spec:
-                replicas: 1
-                selector:
-                  matchLabels:
-                    app: dynamodb-table-test
-                template:
-                  metadata:
-                    labels:
-                      app: dynamodb-table-test
-                  spec:
-                    serviceAccountName: example-app
-                    containers:
-                    - name: aws-cli
-                      image: amazon/aws-cli:latest
-                      env:
-                        - name: AWS_DEFAULT_REGION
-                          valueFrom:
-                            secretKeyRef:
-                              name: example-application-secrets
-                              key: region
-                        - name: TABLE_NAME
-                          valueFrom:
-                            secretKeyRef:
-                              name: example-application-secrets
-                              key: tableName
-                        - name: TEST_KEY
-                          value: '{"hashKey": {"S":"test1"}}'
-                      command:
-                        - "/bin/bash"
-                      args:
-                        - "-c"
-                        - 'while true; do echo "putting item"; aws dynamodb put-item --table-name $TABLE_NAME  --item "$TEST_KEY" || exit 10; sleep 120; echo "removing item"; aws dynamodb delete-item --table-name $TABLE_NAME --key "$TEST_KEY"; sleep 120 ; done'
-      patches:
-        - type: FromCompositeFieldPath
-          fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
-          toFieldPath: spec.forProvider.manifest.metadata.namespace

--- a/examples/aws-provider/composite-resources/example-application/example-application-app.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application-app.yaml
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: "example-app"
+spec:
+  selector:
+    matchLabels:
+      app: dynamodb-table-test
+  template:
+    metadata:
+      labels:
+        app: dynamodb-table-test
+    spec:
+      serviceAccountName: example-app
+      containers:
+      - name: aws-cli
+        image: amazon/aws-cli:latest
+        env:
+          - name: AWS_DEFAULT_REGION
+            valueFrom:
+              secretKeyRef:
+                name: example-application-secrets
+                key: region
+          - name: TABLE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: example-application-secrets
+                key: tableName
+          - name: TEST_KEY
+            value: '{"hashKey": {"S":"test1"}}'
+        command:
+          - "/bin/bash"
+        args:
+          - "-c"
+          - 'while true; do echo "putting item"; aws dynamodb put-item --table-name $TABLE_NAME  --item "$TEST_KEY" || exit 10; sleep 120; echo "removing item"; aws dynamodb delete-item --table-name $TABLE_NAME --key "$TEST_KEY"; sleep 120 ; done'

--- a/examples/aws-provider/composite-resources/example-application/example-application-db.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application-db.yaml
@@ -10,7 +10,7 @@ spec:
   writeConnectionSecretToRef:
     name: example-application-secrets
   resourceConfig:
-    providerConfigName: default
+    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/example-application/example-application-db.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application-db.yaml
@@ -2,24 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: awsblueprints.io/v1alpha1
-kind: ExampleApp
+kind: DynamoDBExample
 metadata:
-  name: example-application
+  name: example-app
   namespace: example-app
 spec:
   writeConnectionSecretToRef:
     name: example-application-secrets
   resourceConfig:
-    providerConfigName: aws-provider-config
+    providerConfigName: default
     region: us-west-2
     tags:
       - key: env
         value: test
       - key: anotherKey
         value: anotherValue
-  accountId: "123456789"
-  eksOIDC: "oidc.eks.us-west-2.amazonaws.com/id/123456789ABCDEFG"
-  permissionsBoundaryArn: "arn:aws:iam::123456789:policy/crossplaneBoundary"
+  accountId: "${ACCOUNT_ID}"
+  eksOIDC: "${OIDC_PROVIDER}"
+  permissionsBoundaryArn: "${PERMISSION_BOUNDARY_ARN}"
   tableSpec:
     hashKeyName: id
     hashKeyType: S


### PR DESCRIPTION
### What does this PR do?

Split the composite example application into AWS resources and APP

### Motivation

I was trying out the current example and was not working, app would come up and secret was not populated with values.

### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

The app is hidden inside the composition with what the app was suppose to do

This PR makes the app logic visible, also the deployment is a two stage deploy the AWS resources, wait for it do be ready then deploy the app.

I could add a init container to the app, or modify the composition to add a secret observe policy to fix the race condition, but still the problem of what is the app suppose to do is hidden.

