### PR TITLE
fix irsa composition passing config provider name

### DIFF
--- a/compositions/aws-provider/irsa/irsa-exact.yaml
+++ b/compositions/aws-provider/irsa/irsa-exact.yaml
@@ -13,11 +13,8 @@ spec:
   patchSets:
     - name: common-fields
       patches:
-        - fromFieldPath: spec.resourceConfig
-          toFieldPath: spec.resourceConfig
-          policy:
-            mergeOptions:
-              keepMapValues: true
+        - fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
   resources:
     - name: iam-role
       base:


### PR DESCRIPTION
Signed-off-by: Carlos Santana <csantana23@gmail.com>


### What does this PR do?

fix irsa composition passing config provider name

### Motivation

The composition for irsa is broken due to not passing the config provider name from the claim down to managed resources of type Role. When is not passed the default value for config provider name is `default` and if user didn't name the config provider `default` the managed resource fails


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
