### PR TITLE
make providerConfigName optional and default

### DIFF
--- a/bootstrap/eksctl/crossplane/aws-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/aws-provider-config.yaml
@@ -4,7 +4,7 @@
 apiVersion: aws.crossplane.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: aws-provider-config
+  name: default
 spec:
 #  assumeRoleARN: "ARN"
   credentials:

--- a/bootstrap/eksctl/crossplane/aws-provider-vault-secret.yaml
+++ b/bootstrap/eksctl/crossplane/aws-provider-vault-secret.yaml
@@ -1,9 +1,9 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws
+  name: default
 spec:
-  package: "crossplane/provider-aws:v0.29.0"
+  package: "crossplane/provider-aws:v0.34.0"
   controllerConfigRef:
     name: provider-aws-config
 ---

--- a/bootstrap/eksctl/crossplane/aws-provider.yaml
+++ b/bootstrap/eksctl/crossplane/aws-provider.yaml
@@ -6,7 +6,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: "xpkg.upbound.io/crossplane-contrib/provider-aws:v0.33.0"
+  package: "crossplane/provider-aws:v0.34.0"
   controllerConfigRef:
     name: provider-aws-config
 ---

--- a/bootstrap/eksctl/crossplane/upbound-aws-provider-config.yaml
+++ b/bootstrap/eksctl/crossplane/upbound-aws-provider-config.yaml
@@ -4,7 +4,7 @@
 apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
-  name: aws-provider-config
+  name: default
 spec:
   credentials:
     source: IRSA

--- a/bootstrap/eksctl/crossplane/upbound-aws-provider.yaml
+++ b/bootstrap/eksctl/crossplane/upbound-aws-provider.yaml
@@ -6,7 +6,7 @@ kind: Provider
 metadata:
   name: provider-aws
 spec:
-  package: "xpkg.upbound.io/upbound/provider-aws:v0.20.0"
+  package: "xpkg.upbound.io/upbound/provider-aws:v0.22.0"
   controllerConfigRef:
     name: upbound-provider-aws
 ---

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -81,7 +81,7 @@ locals {
 #---------------------------------------------------------------
 
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.19.0"
 
   # EKS CONTROL PLANE VARIABLES
   cluster_name    = local.cluster_name
@@ -109,7 +109,7 @@ module "eks_blueprints" {
 #---------------------------------------------------------------
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.19.0"
 
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 

--- a/compositions/aws-provider/cloudfront/definition.yaml
+++ b/compositions/aws-provider/cloudfront/definition.yaml
@@ -57,7 +57,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/dynamodb/definition.yaml
+++ b/compositions/aws-provider/dynamodb/definition.yaml
@@ -193,7 +193,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -132,7 +132,6 @@ spec:
                       type: string
 
                   required:
-                    - providerConfigName
                     - region
               required:
                 - parameters

--- a/compositions/aws-provider/elasticache-redis/definition.yaml
+++ b/compositions/aws-provider/elasticache-redis/definition.yaml
@@ -74,7 +74,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/example-application/definition.yaml
+++ b/compositions/aws-provider/example-application/definition.yaml
@@ -65,7 +65,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/iam-policy/definition.yaml
+++ b/compositions/aws-provider/iam-policy/definition.yaml
@@ -53,7 +53,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/irsa/definition.yaml
+++ b/compositions/aws-provider/irsa/definition.yaml
@@ -65,7 +65,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/rds/definition.yaml
+++ b/compositions/aws-provider/rds/definition.yaml
@@ -90,7 +90,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/s3/definition.yaml
+++ b/compositions/aws-provider/s3/definition.yaml
@@ -58,7 +58,6 @@ spec:
                         type: object
                       type: array
                   required:
-                  - providerConfigName
                   - region
                   - tags
                   type: object

--- a/compositions/aws-provider/vpc-subnets/definition.yaml
+++ b/compositions/aws-provider/vpc-subnets/definition.yaml
@@ -173,7 +173,6 @@ spec:
                       type: string
 
                   required:
-                    - providerConfigName
                     - region
               required:
                 - parameters

--- a/compositions/aws-provider/vpc/definition.yaml
+++ b/compositions/aws-provider/vpc/definition.yaml
@@ -92,7 +92,6 @@ spec:
                       type: string
 
                   required:
-                    - providerConfigName
                     - region
               required:
                 - parameters

--- a/examples/aws-provider/composite-resources/cloudfront/oai-s3.yaml
+++ b/examples/aws-provider/composite-resources/cloudfront/oai-s3.yaml
@@ -13,7 +13,6 @@ spec:
   writeConnectionSecretToRef:
     name: cdn-info
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
@@ -16,7 +16,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-table-on-demand-composite-key
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
@@ -16,7 +16,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-table-on-demand-partition-key
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
@@ -18,7 +18,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-table-provisioned-composite-key-gsi
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
@@ -18,7 +18,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-table-on-demand-partition-key-lsi
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
@@ -16,7 +16,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-table-on-demand-partition-key
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/eks/eks-claim.yaml
+++ b/examples/aws-provider/composite-resources/eks/eks-claim.yaml
@@ -36,7 +36,6 @@ spec:
       awsblueprints.io/subnet-selection: id
       service: eks
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: eu-west-1
   parameters:
     #EKS Input parameters

--- a/examples/aws-provider/composite-resources/elasticache-redis/rediscluster.yaml
+++ b/examples/aws-provider/composite-resources/elasticache-redis/rediscluster.yaml
@@ -10,5 +10,4 @@ spec:
     - subnet-1234abcd
   resourceConfig:
     region: us-east-1
-    providerConfigName: my-aws-provider
     tags: []

--- a/examples/aws-provider/composite-resources/example-application/example-application.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application.yaml
@@ -10,7 +10,6 @@ spec:
   writeConnectionSecretToRef:
     name: example-application-secrets
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/iam/iam-dynamodb-read.yaml
+++ b/examples/aws-provider/composite-resources/iam/iam-dynamodb-read.yaml
@@ -14,7 +14,6 @@ spec:
       iam.awsblueprints.io/policy-type: read
       iam.awsblueprints.io/service: dynamodb-table
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/aurora-postgres.yaml
@@ -34,7 +34,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-aurora-postgresql-db # secret contains endpoint, username, and password.
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: testKey

--- a/examples/aws-provider/composite-resources/rds/postgres.yaml
+++ b/examples/aws-provider/composite-resources/rds/postgres.yaml
@@ -23,7 +23,6 @@ spec:
   writeConnectionSecretToRef:
     name: test-postgresql-db # secret contains endpoint, username, and password.
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/s3/general-purpose.yaml
+++ b/examples/aws-provider/composite-resources/s3/general-purpose.yaml
@@ -15,7 +15,6 @@ spec:
   writeConnectionSecretToRef:
     name: bucket-info
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: us-west-2
     tags:
       - key: env

--- a/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
+++ b/examples/aws-provider/composite-resources/vpc-subnets/vpc-subnets-claim.yaml
@@ -27,7 +27,6 @@ spec:
       awsblueprints.io/network-id: "false"
       service: vpcsubnet
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: eu-west-1
   parameters:
     #vpc input

--- a/examples/aws-provider/composite-resources/vpc/vpc.yaml
+++ b/examples/aws-provider/composite-resources/vpc/vpc.yaml
@@ -16,7 +16,6 @@ spec:
       service: vpc
       compute: managedamazon-vpc
   resourceConfig:
-    providerConfigName: aws-provider-config
     region: eu-west-1
   parameters:
     vpcName: aws-provider-vpc


### PR DESCRIPTION
### What does this PR do?

make providerConfigName optional and default

### Motivation

- When an user that is creating a claim which is a namespaced resource, she might not have cluster scope access to know the name of the provider config. The provider config name should not be a concern required to be exposed to the claim.
- If a providerConfig name is not provider crossplane will default to the value `default` this is an option to the platform team to create the resource with this name or not. 
- The user can always provide a providerConfig name and this is optional

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
