### PR TITLE
ensure dynamodb connection secrets are populated

### DIFF
--- a/compositions/aws-provider/dynamodb/on-demand-composite-key.yaml
+++ b/compositions/aws-provider/dynamodb/on-demand-composite-key.yaml
@@ -11,7 +11,6 @@ metadata:
     dynamodb.awsblueprints.io/capacity: on-demand
     dynamodb.awsblueprints.io/pkType: composite
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
@@ -33,10 +32,12 @@ spec:
   resources:
     - name: table
       connectionDetails:
-        - name: tableName
-          fromConnectionSecretKey: tableName
-        - name: tableArn
-          fromConnectionSecretKey: tableArn
+        - type: FromFieldPath
+          name: tableName
+          fromFieldPath: status.atProvider.tableName
+        - type: FromFieldPath
+          name: tableArn
+          fromFieldPath: status.atProvider.tableARN
         - type: FromFieldPath
           name: region
           fromFieldPath: spec.forProvider.region
@@ -44,9 +45,6 @@ spec:
         apiVersion: dynamodb.aws.crossplane.io/v1alpha1
         kind: Table
         spec:
-          writeConnectionSecretToRef:
-            namespace: crossplane-system
-            name: ""
           deletionPolicy: Delete
           forProvider:
             attributeDefinitions:
@@ -73,14 +71,6 @@ spec:
             mergeOptions:
               appendSlice: true
               keepMapValues: true
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-dynamodb-table"
         - type: FromCompositeFieldPath
           fromFieldPath: spec.tableIndex.hashKeyName
           toFieldPath: spec.forProvider.attributeDefinitions[0].attributeName

--- a/compositions/aws-provider/dynamodb/on-demand-partition-key.yaml
+++ b/compositions/aws-provider/dynamodb/on-demand-partition-key.yaml
@@ -11,7 +11,6 @@ metadata:
     dynamodb.awsblueprints.io/capacity: on-demand
     dynamodb.awsblueprints.io/pkType: partition
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
@@ -33,10 +32,12 @@ spec:
   resources:
     - name: table
       connectionDetails:
-        - name: tableName
-          fromConnectionSecretKey: tableName
-        - name: tableArn
-          fromConnectionSecretKey: tableArn
+        - type: FromFieldPath
+          name: tableName
+          fromFieldPath: status.atProvider.tableName
+        - type: FromFieldPath
+          name: tableArn
+          fromFieldPath: status.atProvider.tableARN
         - type: FromFieldPath
           name: region
           fromFieldPath: spec.forProvider.region
@@ -44,9 +45,6 @@ spec:
         apiVersion: dynamodb.aws.crossplane.io/v1alpha1
         kind: Table
         spec:
-          writeConnectionSecretToRef:
-            namespace: crossplane-system
-            name: ""
           deletionPolicy: Delete
           forProvider:
             attributeDefinitions:
@@ -69,14 +67,6 @@ spec:
             mergeOptions:
               appendSlice: true
               keepMapValues: true
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-dynamodb-table"
         - type: FromCompositeFieldPath
           fromFieldPath: spec.tableIndex.hashKeyName
           toFieldPath: spec.forProvider.attributeDefinitions[0].attributeName

--- a/compositions/aws-provider/dynamodb/provisioned-composite-gsi.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-gsi.yaml
@@ -13,7 +13,6 @@ metadata:
     dynamodb.awsblueprints.io/secondaryIndex: global
     dynamodb.awsblueprints.io/secondaryIndexCount: "1"
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
@@ -74,10 +73,12 @@ spec:
   resources:
     - name: table
       connectionDetails:
-        - name: tableName
-          fromConnectionSecretKey: tableName
-        - name: tableArn
-          fromConnectionSecretKey: tableArn
+        - type: FromFieldPath
+          name: tableName
+          fromFieldPath: status.atProvider.tableName
+        - type: FromFieldPath
+          name: tableArn
+          fromFieldPath: status.atProvider.tableARN
         - type: FromFieldPath
           name: region
           fromFieldPath: spec.forProvider.region
@@ -85,9 +86,6 @@ spec:
         apiVersion: dynamodb.aws.crossplane.io/v1alpha1
         kind: Table
         spec:
-          writeConnectionSecretToRef:
-            namespace: crossplane-system
-            name: ""
           deletionPolicy: Delete
           forProvider:
             attributeDefinitions:
@@ -128,14 +126,6 @@ spec:
             mergeOptions:
               appendSlice: true
               keepMapValues: true
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-dynamodb-table"
         - type: FromCompositeFieldPath
           fromFieldPath: spec.tableIndex.hashKeyName
           toFieldPath: spec.forProvider.attributeDefinitions[0].attributeName

--- a/compositions/aws-provider/dynamodb/provisioned-composite-key.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-key.yaml
@@ -11,7 +11,6 @@ metadata:
     dynamodb.awsblueprints.io/capacity: provisioned
     dynamodb.awsblueprints.io/pkType: composite
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
@@ -33,10 +32,12 @@ spec:
   resources:
     - name: table
       connectionDetails:
-        - name: tableName
-          fromConnectionSecretKey: tableName
-        - name: tableArn
-          fromConnectionSecretKey: tableArn
+        - type: FromFieldPath
+          name: tableName
+          fromFieldPath: status.atProvider.tableName
+        - type: FromFieldPath
+          name: tableArn
+          fromFieldPath: status.atProvider.tableARN
         - type: FromFieldPath
           name: region
           fromFieldPath: spec.forProvider.region
@@ -76,14 +77,6 @@ spec:
             mergeOptions:
               appendSlice: true
               keepMapValues: true
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-dynamodb-table"
         - type: FromCompositeFieldPath
           fromFieldPath: spec.tableIndex.hashKeyName
           toFieldPath: spec.forProvider.attributeDefinitions[0].attributeName

--- a/compositions/aws-provider/dynamodb/provisioned-composite-lsi.yaml
+++ b/compositions/aws-provider/dynamodb/provisioned-composite-lsi.yaml
@@ -13,7 +13,6 @@ metadata:
     dynamodb.awsblueprints.io/secondaryIndex: local
     dynamodb.awsblueprints.io/secondaryIndexCount: "1"
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XDynamoDBTable
@@ -62,10 +61,12 @@ spec:
   resources:
     - name: table
       connectionDetails:
-        - name: tableName
-          fromConnectionSecretKey: tableName
-        - name: tableArn
-          fromConnectionSecretKey: tableArn
+        - type: FromFieldPath
+          name: tableName
+          fromFieldPath: status.atProvider.tableName
+        - type: FromFieldPath
+          name: tableArn
+          fromFieldPath: status.atProvider.tableARN
         - type: FromFieldPath
           name: region
           fromFieldPath: spec.forProvider.region
@@ -73,9 +74,6 @@ spec:
         apiVersion: dynamodb.aws.crossplane.io/v1alpha1
         kind: Table
         spec:
-          writeConnectionSecretToRef:
-            namespace: crossplane-system
-            name: ""
           deletionPolicy: Delete
           forProvider:
             attributeDefinitions:
@@ -116,14 +114,6 @@ spec:
             mergeOptions:
               appendSlice: true
               keepMapValues: true
-        - fromFieldPath: spec.writeConnectionSecretToRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.uid
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-dynamodb-table"
         - type: FromCompositeFieldPath
           fromFieldPath: spec.tableIndex.hashKeyName
           toFieldPath: spec.forProvider.attributeDefinitions[0].attributeName

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-composite.yaml
@@ -13,7 +13,7 @@ spec:
       awsblueprints.io/environment: dev
       dynamodb.awsblueprints.io/capacity: on-demand
       dynamodb.awsblueprints.io/pkType: composite
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: test-table-on-demand-composite-key
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-on-demand-partition.yaml
@@ -13,7 +13,7 @@ spec:
       awsblueprints.io/environment: dev
       dynamodb.awsblueprints.io/capacity: on-demand
       dynamodb.awsblueprints.io/pkType: partition
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: test-table-on-demand-partition-key
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-gsi.yaml
@@ -15,7 +15,7 @@ spec:
       dynamodb.awsblueprints.io/pkType: composite
       dynamodb.awsblueprints.io/secondaryIndex: global
       dynamodb.awsblueprints.io/secondaryIndexCount: "1"
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: test-table-provisioned-composite-key-gsi
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite-lsi.yaml
@@ -15,7 +15,7 @@ spec:
       dynamodb.awsblueprints.io/pkType: composite
       dynamodb.awsblueprints.io/secondaryIndex: local
       dynamodb.awsblueprints.io/secondaryIndexCount: "1"
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: test-table-on-demand-partition-key-lsi
   resourceConfig:
     providerConfigName: aws-provider-config

--- a/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
+++ b/examples/aws-provider/composite-resources/dynamodb/dynamodb-provisioned-composite.yaml
@@ -13,7 +13,7 @@ spec:
       awsblueprints.io/environment: dev
       dynamodb.awsblueprints.io/capacity: provisioned
       dynamodb.awsblueprints.io/pkType: composite
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: test-table-on-demand-partition-key
   resourceConfig:
     providerConfigName: aws-provider-config


### PR DESCRIPTION
### What does this PR do?

imports dynamodb connection details directly from managed resource's status field instead of relying on undocumented secrets exported by the MR.
This also updates dynamodb compositions to use `publishConnectionDetailsTo` instead of `writeConnectionSecretToRef`. The latter is deprecated. 

### Motivation
It's not immediately clear where  connection details such as dynamod db table name and ARN are coming from in the previous example. This makes it clear where it is getting its information from.

