### PR TITLE
remove write connection secrets field

### DIFF
--- a/compositions/aws-provider/iam-policy/dynamodb-manage-table.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-manage-table.yaml
@@ -11,7 +11,6 @@ metadata:
     iam.awsblueprints.io/policy-type: manage
     iam.awsblueprints.io/service: dynamodb
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XIAMPolicy

--- a/compositions/aws-provider/iam-policy/dynamodb-read.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-read.yaml
@@ -11,7 +11,6 @@ metadata:
     iam.awsblueprints.io/policy-type: read
     iam.awsblueprints.io/service: dynamodb-table
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XIAMPolicy

--- a/compositions/aws-provider/iam-policy/dynamodb-write.yaml
+++ b/compositions/aws-provider/iam-policy/dynamodb-write.yaml
@@ -11,7 +11,6 @@ metadata:
     iam.awsblueprints.io/policy-type: write
     iam.awsblueprints.io/service: dynamodb-table
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XIAMPolicy


### PR DESCRIPTION
### What does this PR do?

Removes `writeConnectionSecretsToNamespace` and let the default StoreConfig take care of it. This field is deprecated. https://doc.crds.dev/github.com/crossplane/crossplane/apiextensions.crossplane.io/Composition/v1@v1.10.1#spec-writeConnectionSecretsToNamespace 


