### PR TITLE
ensure example application secrets are created

### DIFF
--- a/compositions/aws-provider/example-application/definition.yaml
+++ b/compositions/aws-provider/example-application/definition.yaml
@@ -97,5 +97,9 @@ spec:
                   type: string
                 writePolicyArn:
                   type: string
+                xirsaObjectName:
+                  type: string
+                xDynamoDBTableObjectName:
+                  type: string
               type: object
           type: object

--- a/compositions/aws-provider/example-application/example-application.yaml
+++ b/compositions/aws-provider/example-application/example-application.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     awsblueprints.io/environment: dev
 spec:
-  writeConnectionSecretsToNamespace: crossplane-system
   compositeTypeRef:
     apiVersion: awsblueprints.io/v1alpha1
     kind: XExampleApp
@@ -54,6 +53,9 @@ spec:
         - type: ToCompositeFieldPath
           fromFieldPath: spec.tableSpec.hashKeyType
           toFieldPath: spec.tableIndex.hashKeyType
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: status.xDynamoDBTableObjectName
     - name: read-policy
       base:
         apiVersion: awsblueprints.io/v1alpha1
@@ -99,6 +101,8 @@ spec:
         apiVersion: awsblueprints.io/v1alpha1
         kind: XIRSA
         spec:
+          compositionRef:
+            name: irsa-exact.awsblueprints.io
           awsAccountID: ""
           eksOIDC: ""
           permissionsBoundaryArn: ""
@@ -122,11 +126,22 @@ spec:
           toFieldPath: spec.policyArns[0]
         - fromFieldPath: status.writePolicyArn
           toFieldPath: spec.policyArns[1]
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: status.xirsaObjectName
     - name: example-app
       base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
         kind: Object
         spec:
+          # Not strictly required but is here as an example.
+          references:
+            - dependsOn:
+                apiVersion: awsblueprints.io/v1alpha1
+                kind: XIRSA
+            - dependsOn:
+                apiVersion: awsblueprints.io/v1alpha1
+                kind: XDynamoDBTable
           forProvider:
             manifest:
               apiVersion: apps/v1
@@ -172,3 +187,9 @@ spec:
         - type: FromCompositeFieldPath
           fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
           toFieldPath: spec.forProvider.manifest.metadata.namespace
+        - type: FromCompositeFieldPath
+          fromFieldPath: status.xirsaObjectName
+          toFieldPath: spec.references[0].dependsOn.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: status.xDynamoDBTableObjectName
+          toFieldPath: spec.references[1].dependsOn.name

--- a/examples/aws-provider/composite-resources/example-application/example-application.yaml
+++ b/examples/aws-provider/composite-resources/example-application/example-application.yaml
@@ -7,7 +7,7 @@ metadata:
   name: example-application
   namespace: example-app
 spec:
-  writeConnectionSecretToRef:
+  publishConnectionDetailsTo:
     name: example-application-secrets
   resourceConfig:
     providerConfigName: aws-provider-config


### PR DESCRIPTION
### What does this PR do?
Ensures example application secrets are created and add an example of using Kubernetes provider's dependency declaration. Note that It probably makes more sense to create a k8s secret in composition instead of relying on claim secret. I will likely do that in the future. 


### Motivation

@csantanapr mentioned how example application was not working in #72 


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
