### PR TITLE
set default node size to m5.large

### DIFF
--- a/bootstrap/eksctl/eksctl.yaml
+++ b/bootstrap/eksctl/eksctl.yaml
@@ -9,7 +9,7 @@ metadata:
   version: "1.24"
 managedNodeGroups:
   - name: managed-ng-1
-    instanceType: t3.small
+    instanceType: m5.large
     minSize: 2
     maxSize: 3
 iam:

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -103,7 +103,7 @@ module "eks_blueprints" {
   managed_node_groups = {
     mg = {
       node_group_name = "managed-on-demand"
-      instance_types  = ["t3.small"]
+      instance_types  = ["m5.large"]
       min_size        = 2
       subnet_ids      = module.vpc.private_subnets
     }

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -105,6 +105,7 @@ module "eks_blueprints" {
       node_group_name = "managed-on-demand"
       instance_types  = ["m5.large"]
       min_size        = 2
+      max_size        = 3
       subnet_ids      = module.vpc.private_subnets
     }
   }


### PR DESCRIPTION
### What does this PR do?

Set node size to `m5.large` for both eksctl and terraform

### Motivation

To allow user to run EMR on EKS

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
