### PR TITLE
feat: adding upbound aws and helm providers

### DIFF
--- a/bootstrap/terraform/README.md
+++ b/bootstrap/terraform/README.md
@@ -61,7 +61,7 @@ terraform init
 Verify the resources created by this execution
 
 ```shell script
-export AWS_REGION=<ENTER YOUR REGION>   # Select your own region
+export TF_VAR_region=<ENTER YOUR REGION>   # Select your own region
 terraform plan
 ```
 

--- a/bootstrap/terraform/README.md
+++ b/bootstrap/terraform/README.md
@@ -28,7 +28,9 @@ graph TD;
     ManagedNodeGroup-->|enable_crossplane=true|id2([Crossplane]);
     subgraph Kubernetes Add-ons
     id2([Crossplane])-.->|crossplane_aws_provider.enable=true|id3([AWS-Provider]);
-    id2([Crossplane])-.->|crossplane_kubernetes_provider.enable=true|id4([Kubernetes-Provider]);
+    id2([Crossplane])-.->|crossplane_upbound_aws_provider.enable=true|id4([Upbound-AWS-Provider]);
+    id2([Crossplane])-.->|crossplane_kubernetes_provider.enable=true|id5([Kubernetes-Provider]);
+    id2([Crossplane])-.->|crossplane_helm_provider.enable=true|id6([Helm-Provider]);
     end
     end
 ```
@@ -98,8 +100,10 @@ kubectl get providers
 The expected output looks like this:
 ```
 NAME                  INSTALLED   HEALTHY   PACKAGE                                                         AGE
-aws-provider          True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.34.0         36m
-kubernetes-provider   True        True      xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.5.0   36m
+aws-provider          True        True      xpkg.upbound.io/crossplane-contrib/provider-aws:v0.36.0         36m
+kubernetes-provider   True        True      xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.6.0   36m
+provider-helm         True        True      xpkg.upbound.io/crossplane-contrib/provider-helm:v0.13.0        36m
+upbound-aws-provider  True        True      xpkg.upbound.io/upbound/provider-aws:v0.27.0                    36m
 ```
 Run the following commands to get the list of provider configs:
 ```shell script
@@ -109,6 +113,9 @@ The expected output looks like this:
 ```
 NAME                                                   AGE
 providerconfig.aws.crossplane.io/aws-provider-config   36m
+
+NAME                                        AGE
+providerconfig.helm.crossplane.io/default   36m
 
 NAME                                                                 AGE
 providerconfig.kubernetes.crossplane.io/kubernetes-provider-config   36m

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -97,7 +97,8 @@ module "eks_blueprints_kubernetes_addons" {
   # Crossplane community AWS Provider deployment
   #---------------------------------------------------------
   crossplane_aws_provider = {
-    enable = true
+    enable                = true
+    provider_config = "aws-provider-config"
     # to override the default irsa policy:
     # additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
   }

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -41,39 +41,6 @@ locals {
   cluster_version = var.cluster_version
   cluster_name    = local.name
 
-  crossplane_helm_config = {
-    #  name       = "crossplane"
-    #  chart      = "crossplane"
-    #  repository = "https://charts.crossplane.io/stable/"
-    version = "1.10.1"
-    #  namespace  = "crossplane-system"
-    #  values = [templatefile("${path.module}/values.yaml", {
-    #    operating-system = "linux"
-    #  })]
-  }
-
-  # NOTE: Crossplane requires Admin like permissions to create and update resources similar to Terraform deploy role.
-  # This example config uses AdministratorAccess for demo purpose only, but you should select a policy with the minimum permissions required to provision your resources
-  crossplane_aws_provider = {
-    enable                   = true
-    provider_aws_version     = "v0.34.0"
-    additional_irsa_policies = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-    # name                     = "aws-provider"
-    # service_account          = "aws-provider"
-    # provider_config          = "default"
-    # controller_config        = "aws-controller-config"
-  }
-
-  crossplane_kubernetes_provider = {
-    enable                      = true
-    provider_kubernetes_version = "v0.5.0"
-    #  name                        = "kubernetes-provider"
-    #  service_account             = "kubernetes-provider"
-    #  provider_config             = "default"
-    #  controller_config           = "kubernetes-controller-config"
-    #  cluster_role                = "cluster-admin"
-  }
-
   vpc_name = local.name
   vpc_cidr = "10.0.0.0/16"
   azs      = slice(data.aws_availability_zones.available.names, 0, 2)
@@ -89,7 +56,7 @@ locals {
 #---------------------------------------------------------------
 
 module "eks_blueprints" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints?ref=v4.22.0"
 
   # EKS CONTROL PLANE VARIABLES
   cluster_name    = local.cluster_name
@@ -118,26 +85,45 @@ module "eks_blueprints" {
 #---------------------------------------------------------------
 
 module "eks_blueprints_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.18.1"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.22.0"
 
   eks_cluster_id = module.eks_blueprints.eks_cluster_id
 
   # Deploy Crossplane
+  # Default helm chart and providers values set at https://github.com/aws-ia/terraform-aws-eks-blueprints/blob/main/modules/kubernetes-addons/crossplane/locals.tf
   enable_crossplane = true
 
-  crossplane_helm_config = local.crossplane_helm_config
+  #---------------------------------------------------------
+  # Crossplane community AWS Provider deployment
+  #---------------------------------------------------------
+  crossplane_aws_provider = {
+    enable = true
+    # to override the default irsa policy:
+    # additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  }
 
   #---------------------------------------------------------
-  # Crossplane AWS Provider deployment
-  #   Creates ProviderConfig name as "aws-provider-config"
+  # Crossplane Upbound AWS Provider deployment
   #---------------------------------------------------------
-  crossplane_aws_provider = local.crossplane_aws_provider
+  crossplane_upbound_aws_provider = {
+    enable = true
+    # to override the default irsa policy:
+    # additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  }
 
   #---------------------------------------------------------
   # Crossplane Kubernetes Provider deployment
-  #   Creates ProviderConfig name as "kubernetes-provider-config"
   #---------------------------------------------------------
-  crossplane_kubernetes_provider = local.crossplane_kubernetes_provider
+  crossplane_kubernetes_provider = {
+    enable = true
+  }
+
+  #---------------------------------------------------------
+  # Crossplane Helm Provider deployment
+  #---------------------------------------------------------
+  crossplane_helm_provider = {
+    enable = true
+  }
 
   depends_on = [module.eks_blueprints.managed_node_groups]
 }

--- a/bootstrap/terraform/main.tf
+++ b/bootstrap/terraform/main.tf
@@ -97,7 +97,7 @@ module "eks_blueprints_kubernetes_addons" {
   # Crossplane community AWS Provider deployment
   #---------------------------------------------------------
   crossplane_aws_provider = {
-    enable                = true
+    enable          = true
     provider_config = "aws-provider-config"
     # to override the default irsa policy:
     # additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
@@ -107,7 +107,8 @@ module "eks_blueprints_kubernetes_addons" {
   # Crossplane Upbound AWS Provider deployment
   #---------------------------------------------------------
   crossplane_upbound_aws_provider = {
-    enable = true
+    enable          = true
+    provider_config = "aws-provider-config"
     # to override the default irsa policy:
     # additional_irsa_policies = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
   }

--- a/bootstrap/terraform/values.yaml
+++ b/bootstrap/terraform/values.yaml
@@ -1,2 +1,0 @@
-nodeSelector:
-  kubernetes.io/os: ${operating-system}


### PR DESCRIPTION
### What does this PR do?

Adds installation for `helm-provider` and `upbound-aws-provider`.

### Motivation
Resolves: https://github.com/awslabs/crossplane-on-eks/issues/9

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [x] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [X] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [X] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

### For Moderators
- [x] E2E Test successfully complete before merge?

### Additional Notes

Tested upbound aws-provider by successfully creating an S3 bucket:
```
cat <<EOF | kubectl create -f -
apiVersion: s3.aws.upbound.io/v1beta1
kind: Bucket
metadata:
  generateName: test-bucket-
spec:
  forProvider:
    region: us-east-1
  providerConfigRef:
    name: aws-provider-config
EOF
```

Tested helm provider by successfully creating a helm release:
```
cat <<EOF | kubectl create -f -
apiVersion: helm.crossplane.io/v1beta1
kind: Release
metadata:
  name: hello-example
spec:
  forProvider:
    chart:
      name: hello
      repository: https://cloudecho.github.io/charts
      version: 0.1.2
    namespace: hello-example
EOF
```
