### PR TITLE
update eks versions and remove duplicate printer fields

### DIFF
--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -21,15 +21,9 @@ spec:
   versions:
     - name: v1alpha1
       additionalPrinterColumns:
-      - jsonPath: .status.conditions[?(@.type=='Ready')].status
-        name: READY
+      - jsonPath: .status.clusterName
+        name: CLUSTER-NAME
         type: string
-      - jsonPath: .status.conditions[?(@.type=='Synced')].status
-        name: SYNCED
-        type: string
-      - jsonPath: .metadata.creationTimestamp
-        name: AGE
-        type: date
       served: true
       referenceable: true
       schema:
@@ -43,11 +37,10 @@ spec:
                   description: EKS Input parameters
                   type: object
                   properties:
-
                     version:
                       description: Kubernetes Version
                       type: string
-                      enum: [ "1.21", "1.22", "1.23" ]
+                      enum: [ "1.21", "1.22", "1.23", "1.24", "1.25" ]
                     endpointPrivateAccess:
                       description: endpointPrivateAccess
                       type: boolean
@@ -66,6 +59,10 @@ spec:
                       description: Name of network to use for label-based subnet lookup (subnet label 'network.awsblueprints.io/network-id'). Unused in compositions that use explicit subnet Id through the 'subnetIds' parameter
                       type: string
                       default: ""
+                    adminRole:
+                      description: Name of the role in the same account to give administrator access to this cluster.
+                      type: string
+                      default: Admin
                   required:
                     - version
                 managedNodeGroups:
@@ -106,8 +103,6 @@ spec:
                         type: string
                       type: array
                       description: Instance Type.
-                      default:
-                       - m5.large
                   required:
                     - minSize
                 resourceConfig:
@@ -138,5 +133,21 @@ spec:
                 - parameters
                 - resourceConfig
                 - managedNodeGroups
+            status:
+              properties:
+                oidcIssuerUrl:
+                  type: string
+                oidcEKS:
+                  type: string
+                accountID:
+                  type: string
+                nodeGroupArn:
+                  type: string
+                clusterName:
+                  type: string
+                roleArnCAS:
+                  type: string
+                roleArnCSI:
+                  type: string
           required:
             - spec

--- a/compositions/aws-provider/eks/definition.yaml
+++ b/compositions/aws-provider/eks/definition.yaml
@@ -40,7 +40,7 @@ spec:
                     version:
                       description: Kubernetes Version
                       type: string
-                      enum: [ "1.21", "1.22", "1.23", "1.24", "1.25" ]
+                      enum: [ "1.22", "1.23", "1.24", "1.25" ]
                     endpointPrivateAccess:
                       description: endpointPrivateAccess
                       type: boolean

--- a/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group-subnet-labels.yaml
@@ -75,13 +75,11 @@ spec:
             - type: string
               string:
                 fmt: "%s-eks-cluster-conn"
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: status.clusterName
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
-#        - type: ToCompositeFieldPath
-#          fromFieldPath: status.atProvider.identity.oidc.issuer
-#          toFieldPath: status.eks.oidc
-#          policy:
-#            fromFieldPath: Optional
       connectionDetails:
         - name: cluster-ca
           fromConnectionSecretKey: clusterCA
@@ -187,6 +185,7 @@ spec:
               maxSize:
             capacityType:
             instanceTypes:
+              - m5.large
       patches:
         - type: PatchSet
           patchSetName: common-parameters

--- a/compositions/aws-provider/eks/eks-managed-node-group.yaml
+++ b/compositions/aws-provider/eks/eks-managed-node-group.yaml
@@ -16,7 +16,6 @@ spec:
   compositeTypeRef:
     apiVersion: cluster.awsblueprints.io/v1alpha1
     kind: XAmazonEks
-
   patchSets:
     - name: common-parameters
       patches:
@@ -29,10 +28,6 @@ spec:
         - type: FromCompositeFieldPath
           fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region
-#        - type: FromCompositeFieldPath
-#          fromFieldPath: spec.resourceConfig.name
-#          toFieldPath: metadata.annotations[crossplane.io/external-name]
-
   resources:
     - name: eks-cluster
       base:
@@ -73,13 +68,11 @@ spec:
             - type: string
               string:
                 fmt: "%s-eks-cluster-conn"
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: status.clusterName
         - fromFieldPath: spec.writeConnectionSecretToRef.namespace
           toFieldPath: spec.writeConnectionSecretToRef.namespace
-#        - type: ToCompositeFieldPath
-#          fromFieldPath: status.atProvider.identity.oidc.issuer
-#          toFieldPath: status.eks.oidc
-#          policy:
-#            fromFieldPath: Optional
       connectionDetails:
         - name: cluster-ca
           fromConnectionSecretKey: clusterCA
@@ -182,6 +175,7 @@ spec:
               maxSize:
             capacityType:
             instanceTypes:
+              - m5.large
       patches:
         - type: PatchSet
           patchSetName: common-parameters


### PR DESCRIPTION
### What does this PR do?

1. Removes commented out fields
2. Add newer EKS versions to the enum
3. Add fields to support aws-auth config map management


