### PR TITLE
Remove aws-provider-upbound-s3-bucket annotation when creating S3 bucket

### DIFF
--- a/examples/upbound-aws-provider/managed-resources/s3/bucket.yaml
+++ b/examples/upbound-aws-provider/managed-resources/s3/bucket.yaml
@@ -2,8 +2,6 @@ apiVersion: s3.aws.upbound.io/v1beta1
 kind: Bucket
 metadata:
   generateName: upbound-test-bucket-
-  annotations:
-    crossplane.io/external-name: aws-provider-upbound-s3-bucket
   labels:
     testing.upbound.io/example-name: s3
 spec:


### PR DESCRIPTION
With this annotation the S3 bucket upbound-test-bucket was not able to be created due to permissions issues. IRSA was also checked and wired correctly.

Removing the annotation allows the bucket to be created with no issues.


### More

- [x] Yes, I have tested the PR using my local account setup


### For Moderators
- [ ] E2E Test successfully complete before merge?

