### PR TITLE
Creating ElastiCache Redis Replication Group composition for Upbound provider

### DIFF
--- a/compositions/upbound-aws-provider/elasticache/definition.yaml
+++ b/compositions/upbound-aws-provider/elasticache/definition.yaml
@@ -1,0 +1,118 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xredisclusters.cache.awsblueprints.io
+spec:
+  group: cache.awsblueprints.io
+  names:
+    kind: XRedisCluster
+    plural: xredisclusters
+  claimNames:
+    kind: RedisCluster
+    plural: redisclusters
+  connectionSecretKeys:
+    - clusterArn
+    - clusterId
+    - clusterAddress
+    - clusterPort
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            description: "AWS ElastiCache Cluster Spec"
+            properties:
+              clusterNetwork:
+                type: object
+                properties:
+                  subnetGroupName:
+                    type: string
+                  vpcId:
+                    type: string
+                  subnetIds:
+                    type: array
+                    items:
+                      type: string
+              resourceConfig:
+                description: ResourceConfig defines general properties of this AWS
+                type: object
+                properties:
+                  region:
+                    description: Defining region where resources are provisioned.
+                    type: string
+                  providerConfigName:
+                    description: Provider config for IAM Role
+                    type: string
+                  nodeType:
+                    type: string
+                  replicasPerNodeGroup:
+                    type: integer
+                  numNodeGroups:
+                    type: integer
+                  multiAzEnabled:
+                    type: boolean
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: Key-value map of resource tags.
+                    type: object
+                  snapshotRetentionLimit:
+                    description: Automated snapshot retention limit (in days)
+                    type: integer
+                  snapshotWindow:
+                    description: Time window to take automated snapshot
+                    type: string
+                  snapshotName:
+                    description: Name of the snapshot to restore from
+                    type: string
+                  applyImmediately:
+                    description: Apply minor version changes immediately
+                    type: boolean
+                  autoMinorVersionUpgrade:
+                    description: Automatic upgrade minor version of the clsuter
+                    type: string
+                  maintenanceWindow:
+                    description: Maintenance window for the cluster
+                    type: string
+                  notificationTopicArn:
+                    description: Notification SNS ARN
+                    type: string
+                  parameterGroupName:
+                    type: string
+                  logGroup:
+                    type: object
+                    properties:
+                      retentionInDays:
+                        type: integer
+                required:
+                - region
+                - providerConfigName
+                - notificationTopicArn
+          status:
+            type: object
+            properties:
+              clusterArn:
+                type: string
+              clusterId:
+                type: string
+              clusterAddress:
+                type: string
+              clusterPort:
+                type: string
+              securityGroupArn:
+                type: string
+              securityGroupId:
+                type: string
+              subnetGroupArn:
+                type: string
+              subnetGroupName:
+                type: string
+              logGroupArn:
+                type: string
+              logGroupName:
+                type: string

--- a/compositions/upbound-aws-provider/elasticache/definition.yaml
+++ b/compositions/upbound-aws-provider/elasticache/definition.yaml
@@ -13,7 +13,8 @@ spec:
   connectionSecretKeys:
     - clusterArn
     - clusterId
-    - clusterAddress
+    - primaryEndpoint
+    - readerEndpoint
     - clusterPort
   versions:
   - name: v1alpha1
@@ -38,6 +39,8 @@ spec:
                     type: array
                     items:
                       type: string
+                required:
+                  - subnetIds
               resourceConfig:
                 description: ResourceConfig defines general properties of this AWS
                 type: object
@@ -98,9 +101,8 @@ spec:
                         type: integer
                         default: 14
                 required:
-                - region
-                - subnetIds
-                - providerConfigName
+                  - region
+                  - providerConfigName
           status:
             type: object
             properties:
@@ -108,7 +110,9 @@ spec:
                 type: string
               clusterId:
                 type: string
-              clusterAddress:
+              primaryEndpoint:
+                type: string
+              readerEndpoint:
                 type: string
               clusterPort:
                 type: string

--- a/compositions/upbound-aws-provider/elasticache/definition.yaml
+++ b/compositions/upbound-aws-provider/elasticache/definition.yaml
@@ -115,7 +115,7 @@ spec:
               readerEndpoint:
                 type: string
               clusterPort:
-                type: string
+                type: integer
               securityGroupArn:
                 type: string
               securityGroupId:

--- a/compositions/upbound-aws-provider/elasticache/definition.yaml
+++ b/compositions/upbound-aws-provider/elasticache/definition.yaml
@@ -50,6 +50,7 @@ spec:
                     type: string
                   nodeType:
                     type: string
+                    default: cache.t4g.micro
                   replicasPerNodeGroup:
                     type: integer
                   numNodeGroups:
@@ -64,35 +65,42 @@ spec:
                   snapshotRetentionLimit:
                     description: Automated snapshot retention limit (in days)
                     type: integer
+                    default: 7
                   snapshotWindow:
                     description: Time window to take automated snapshot
                     type: string
+                    default: "01:00-02:00"
                   snapshotName:
                     description: Name of the snapshot to restore from
                     type: string
                   applyImmediately:
                     description: Apply minor version changes immediately
                     type: boolean
+                    default: true
                   autoMinorVersionUpgrade:
                     description: Automatic upgrade minor version of the clsuter
                     type: string
+                    default: "true"
                   maintenanceWindow:
                     description: Maintenance window for the cluster
                     type: string
+                    default: "tue:03:00-tue:04:00"
                   notificationTopicArn:
                     description: Notification SNS ARN
                     type: string
                   parameterGroupName:
                     type: string
+                    default: default.redis7.cluster.on
                   logGroup:
                     type: object
                     properties:
                       retentionInDays:
                         type: integer
+                        default: 14
                 required:
                 - region
+                - subnetIds
                 - providerConfigName
-                - notificationTopicArn
           status:
             type: object
             properties:

--- a/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
+++ b/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
@@ -99,6 +99,15 @@ spec:
         - type: ToCompositeFieldPath
           fromFieldPath: status.atProvider.id
           toFieldPath: status.clusterId
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.port
+          toFieldPath: status.clusterPort
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.primaryEndpointAddress
+          toFieldPath: status.primaryEndpoint
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.readerEndpointAddress
+          toFieldPath: status.readerEndpoint
         - type: FromCompositeFieldPath
           fromFieldPath: status.securityGroupId
           toFieldPath: spec.forProvider.securityGroupIds[0]
@@ -133,6 +142,10 @@ spec:
           toFieldPath: spec.writeConnectionSecretToRef.namespace
         - fromFieldPath: metadata.name
           toFieldPath: spec.writeConnectionSecretToRef.name
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-rg-secret"
     - name: redis-sg
       base:
         apiVersion: ec2.aws.upbound.io/v1beta1

--- a/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
+++ b/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
@@ -1,0 +1,230 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xredisclusters.aws.cache.awsblueprints.io
+  labels:
+    provider: aws
+    environment: dev
+    configuration: standard
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: cache.awsblueprints.io/v1alpha1
+    kind: XRedisCluster
+  patchSets:
+    - name: common-fields
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.region
+          toFieldPath: spec.forProvider.region
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.uid
+          toFieldPath: spec.forProvider.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.providerConfigName
+          toFieldPath: spec.providerConfigRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            mergeOptions:
+              keepMapValues: true
+    - name: cluster-options
+      patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.nodeType
+          toFieldPath: spec.forProvider.nodeType
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.replicasPerNodeGroup
+          toFieldPath: spec.forProvider.clusterMode[0].replicasPerNodeGroup
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.numNodeGroups
+          toFieldPath: spec.forProvider.clusterMode[0].numNodeGroups
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.multiAzEnabled
+          toFieldPath: spec.forProvider.multiAzEnabled
+  resources:
+    - name: redis-rg
+      connectionDetails:
+        - type: FromFieldPath
+          name: clusterArn
+          fromFieldPath: status.atProvider.arn
+        - type: FromFieldPath
+          name: clusterId
+          fromFieldPath: status.atProvider.id
+        - type: FromFieldPath
+          name: clusterAddress
+          fromFieldPath: status.atProvider.cacheNodes[0].address
+        - type: FromFieldPath
+          name: clusterPort
+          fromFieldPath: status.atProvider.cacheNodes[0].port
+      base:
+        apiVersion: elasticache.aws.upbound.io/v1beta1
+        kind: ReplicationGroup
+        metadata:
+          name: ec-redis-rg
+        spec:
+          forProvider:
+            description: "ec-redis-rg"
+            engine: redis
+            engineVersion: "7.0"
+            nodeType: cache.t4g.micro
+            clusterMode:
+              - numNodeGroups: 1
+                replicasPerNodeGroup: 0
+            multiAzEnabled: false
+            port: 6379
+            parameterGroupName: default.redis7.cluster.on
+            atRestEncryptionEnabled: true
+            transitEncryptionEnabled: true
+            automaticFailoverEnabled: true
+            subnetGroupNameRef:
+              name: subnetgroup-ec-cluster-via-composition
+            tags:
+              cluster: test-cluster
+              namespace: team-a
+              environment: dev
+              application: my-app
+              snapshotName:
+              from: composition
+            snapshotRetentionLimit: 0
+            snapshotWindow: "09:00-10:00"
+            applyImmediately: true
+            autoMinorVersionUpgrade: "true"
+            maintenanceWindow: "mon:10:40-mon:11:40"
+            notificationTopicArn: arn:aws:sns:us-east-1:791573251752:doNotUse
+            logDeliveryConfiguration:
+              - destination: /aws/elasticache/crossplane-team-c-dev-redis-claim
+                destinationType: cloudwatch-logs
+                logFormat: text
+                logType: engine-log
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: PatchSet
+          patchSetName: cluster-options
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.clusterArn
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.clusterId
+        - type: FromCompositeFieldPath
+          fromFieldPath: status.securityGroupId
+          toFieldPath: spec.forProvider.securityGroupIds[0]
+        - type: FromCompositeFieldPath
+          fromFieldPath: status.subnetGroupName
+          toFieldPath: spec.forProvider.subnetGroupNameRef.name
+        - type: FromCompositeFieldPath
+          fromFieldPath: status.logGroupName
+          toFieldPath: spec.forProvider.logDeliveryConfiguration[0].destination
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.snapshotRetentionLimit
+          toFieldPath: spec.forProvider.snapshotRetentionLimit
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.snapshotWindow
+          toFieldPath: spec.forProvider.snapshotWindow
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.snapshotName
+          toFieldPath: spec.forProvider.snapshotName
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.applyImmediately
+          toFieldPath: spec.forProvider.applyImmediately
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.autoMinorVersionUpgrade
+          toFieldPath: spec.forProvider.autoMinorVersionUpgrade
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.maintenanceWindow
+          toFieldPath: spec.forProvider.maintenanceWindow
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.notificationTopicArn
+          toFieldPath: spec.forProvider.notificationTopicArn
+    - name: redis-sg
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroup
+        metadata:
+          name: security-group-redis-cluster-via-composition
+          labels:
+            security-group-name: sg-for-elasticache-redis-cluster-composition-label
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.clusterNetwork.vpcId
+          toFieldPath: spec.forProvider.vpcId
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.securityGroupId
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.securityGroupArn
+    - name: redis-sg-rule
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          name: security-group-rule-via-composition
+        spec:
+          forProvider:
+            cidrBlocks:
+              - 10.0.0.0/8
+            fromPort: 6379
+            protocol: tcp
+            securityGroupIdSelector:
+              matchLabels:
+                security-group-name: sg-for-elasticache-redis-cluster-composition-label
+            toPort: 6379
+            type: ingress
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+    - name: redis-subnetgroup
+      base:
+        apiVersion: elasticache.aws.upbound.io/v1beta1
+        kind: SubnetGroup
+        metadata:
+          name: subnetgroup-ec-cluster-via-composition
+        spec:
+          forProvider:
+            region: us-east-1
+            tags:
+              cluster: test-cluster
+              namespace: team-a
+              environment: dev
+              application: my-app
+              from: composition
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - fromFieldPath: spec.clusterNetwork.subnetIds
+          toFieldPath: spec.forProvider.subnetIds
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.subnetGroupArn
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.subnetGroupName
+    - name: redis-cw-loggroup
+      base:
+        apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
+        kind: Group
+        metadata:
+          name: cw-loggroup-ec-cluster-via-composition
+        spec:
+          forProvider:
+            retentionInDays: 1
+      patches:
+        - type: PatchSet
+          patchSetName: common-fields
+        - type: FromCompositeFieldPath
+          fromFieldPath: metadata.name
+          toFieldPath: metadata.name
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.arn
+          toFieldPath: status.logGroupArn
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.id
+          toFieldPath: status.logGroupName
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.resourceConfig.logGroup.retentionInDays
+          toFieldPath: spec.forProvider.retentionInDays

--- a/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
+++ b/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
@@ -68,13 +68,11 @@ spec:
             description: "ec-redis-rg"
             engine: redis
             engineVersion: "7.0"
-            nodeType: cache.t4g.micro
             clusterMode:
               - numNodeGroups: 1
                 replicasPerNodeGroup: 0
             multiAzEnabled: false
             port: 6379
-            parameterGroupName: default.redis7.cluster.on
             atRestEncryptionEnabled: true
             transitEncryptionEnabled: true
             automaticFailoverEnabled: true
@@ -87,12 +85,6 @@ spec:
               application: my-app
               snapshotName:
               from: composition
-            snapshotRetentionLimit: 0
-            snapshotWindow: "09:00-10:00"
-            applyImmediately: true
-            autoMinorVersionUpgrade: "true"
-            maintenanceWindow: "mon:10:40-mon:11:40"
-            notificationTopicArn: arn:aws:sns:us-east-1:791573251752:doNotUse
             logDeliveryConfiguration:
               - destination: /aws/elasticache/crossplane-team-c-dev-redis-claim
                 destinationType: cloudwatch-logs

--- a/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
+++ b/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
@@ -67,6 +67,8 @@ spec:
         metadata:
           name: ec-redis-rg
         spec:
+          writeConnectionSecretToRef:
+            namespace: crossplane-system
           forProvider:
             description: "ec-redis-rg"
             engine: redis
@@ -138,14 +140,6 @@ spec:
         - type: FromCompositeFieldPath
           fromFieldPath: spec.resourceConfig.notificationTopicArn
           toFieldPath: spec.forProvider.notificationTopicArn
-        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
-        - fromFieldPath: metadata.name
-          toFieldPath: spec.writeConnectionSecretToRef.name
-          transforms:
-            - type: string
-              string:
-                fmt: "%s-rg-secret"
     - name: redis-sg
       base:
         apiVersion: ec2.aws.upbound.io/v1beta1

--- a/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
+++ b/compositions/upbound-aws-provider/elasticache/elasticache-redis.yaml
@@ -53,11 +53,14 @@ spec:
           name: clusterId
           fromFieldPath: status.atProvider.id
         - type: FromFieldPath
-          name: clusterAddress
-          fromFieldPath: status.atProvider.cacheNodes[0].address
+          name: primaryEndpoint
+          fromFieldPath: status.atProvider.primaryEndpointAddress
+        - type: FromFieldPath
+          name: readerEndpoint
+          fromFieldPath: status.atProvider.readerEndpointAddress
         - type: FromFieldPath
           name: clusterPort
-          fromFieldPath: status.atProvider.cacheNodes[0].port
+          fromFieldPath: status.atProvider.port
       base:
         apiVersion: elasticache.aws.upbound.io/v1beta1
         kind: ReplicationGroup
@@ -75,15 +78,10 @@ spec:
             port: 6379
             atRestEncryptionEnabled: true
             transitEncryptionEnabled: true
-            automaticFailoverEnabled: true
+            automaticFailoverEnabled: false
             subnetGroupNameRef:
               name: subnetgroup-ec-cluster-via-composition
             tags:
-              cluster: test-cluster
-              namespace: team-a
-              environment: dev
-              application: my-app
-              snapshotName:
               from: composition
             logDeliveryConfiguration:
               - destination: /aws/elasticache/crossplane-team-c-dev-redis-claim
@@ -131,6 +129,10 @@ spec:
         - type: FromCompositeFieldPath
           fromFieldPath: spec.resourceConfig.notificationTopicArn
           toFieldPath: spec.forProvider.notificationTopicArn
+        - fromFieldPath: metadata.labels[crossplane.io/claim-namespace]
+          toFieldPath: spec.writeConnectionSecretToRef.namespace
+        - fromFieldPath: metadata.name
+          toFieldPath: spec.writeConnectionSecretToRef.name
     - name: redis-sg
       base:
         apiVersion: ec2.aws.upbound.io/v1beta1
@@ -180,10 +182,6 @@ spec:
           forProvider:
             region: us-east-1
             tags:
-              cluster: test-cluster
-              namespace: team-a
-              environment: dev
-              application: my-app
               from: composition
       patches:
         - type: PatchSet

--- a/compositions/upbound-aws-provider/elasticache/kustomization.yaml
+++ b/compositions/upbound-aws-provider/elasticache/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- definition.yaml
+- elasticache-redis.yaml

--- a/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
+++ b/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
@@ -1,0 +1,33 @@
+apiVersion: cache.awsblueprints.io/v1alpha1
+kind: RedisCluster
+metadata:
+  name: test-cluster-team-a
+  namespace: team-a
+spec:
+  clusterNetwork:
+    vpcId: vpc-0e2fef3e6642bbf88
+    subnetIds:
+      - "subnet-0bd0375a3e60e0406"
+      - "subnet-0ae57e68c63a6c60b"
+  compositionSelector:
+    matchLabels:
+      provider: aws
+      environment: dev
+      configuration: standard
+  resourceConfig:
+    providerConfigName: provider-config-irsa
+    parameterGroupName: default.redis7
+    region: us-east-1
+    tags:
+      cluster: crossplane
+      namespace: team-a
+      environment: dev
+      application: my-app-1
+    snapshotRetentionLimit: 7
+    snapshotWindow: "04:00-06:00"
+    applyImmediately: true
+    autoMinorVersionUpgrade: "true"
+    maintenanceWindow: "tue:08:00-tue:10:00"
+    notificationTopicArn: arn:aws:sns:us-east-1:791573251752:sampleNotification
+    logGroup:
+      retentionInDays: 14

--- a/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
+++ b/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
@@ -15,19 +15,21 @@ spec:
       environment: dev
       configuration: standard
   resourceConfig:
-    providerConfigName: provider-config-irsa
-    parameterGroupName: default.redis7
     region: us-east-1
+    providerConfigName: aws-provider-config
     tags:
       cluster: crossplane
       namespace: team-a
       environment: dev
       application: my-app-1
-    snapshotRetentionLimit: 7
-    snapshotWindow: "04:00-06:00"
-    applyImmediately: true
-    autoMinorVersionUpgrade: "true"
-    maintenanceWindow: "tue:08:00-tue:10:00"
-    notificationTopicArn: arn:aws:sns:us-east-1:791573251752:sampleNotification
+    # Below parameters have default set up in definition
+    parameterGroupName: default.redis7        # Default default.redis7.cluster.on (String)
+    snapshotRetentionLimit: 7                 # Default 7 (integer)
+    snapshotWindow: "04:00-06:00"             # Default "01:00-02:00" (string)
+    applyImmediately: true                    # Default true (boolean)
+    autoMinorVersionUpgrade: "true"           # Default "true" (string)
+    maintenanceWindow: "tue:03:00-tue:04:00"  # Default "tue:03:00-tue:04:00" (string)
     logGroup:
-      retentionInDays: 14
+      retentionInDays: 14                     # Default 14 (integer)
+    # Notification Topic Arn is optional
+    notificationTopicArn: arn:aws:sns:us-east-1:111122223333:sampleNotification

--- a/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
+++ b/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
@@ -6,17 +6,21 @@ metadata:
 spec:
   clusterNetwork:
     vpcId: vpc-123abc
+    # Required Fields (subnetIds)
     subnetIds:
       - "subnet-001"
       - "subnet-002"
+      - "subnet-003"
   compositionSelector:
     matchLabels:
       provider: aws
       environment: dev
       configuration: standard
   resourceConfig:
+    # Required Fields (region, providerConfigName)
     region: us-east-1
     providerConfigName: aws-provider-config
+    # Optional Fields
     tags:
       cluster: crossplane
       namespace: team-a

--- a/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
+++ b/examples/upbound-aws-provider/composite-resources/elasticache-redis.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: team-a
 spec:
   clusterNetwork:
-    vpcId: vpc-0e2fef3e6642bbf88
+    vpcId: vpc-123abc
     subnetIds:
-      - "subnet-0bd0375a3e60e0406"
-      - "subnet-0ae57e68c63a6c60b"
+      - "subnet-001"
+      - "subnet-002"
   compositionSelector:
     matchLabels:
       provider: aws


### PR DESCRIPTION
### What does this PR do?
Creates a ReplicationGroup for ElastiCache Redis cluster.   Along with cluster, composition also creates SubnetGroup, SecurityGroup, SecurityGroup Rule and CloudWatch LogGroups.


### Motivation
Contributing to open source community.


### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [X] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
