### PR TITLE
Additional gatekeeper policies

### DIFF
--- a/examples/gatekeeper/region-restrict/README.md
+++ b/examples/gatekeeper/region-restrict/README.md
@@ -1,0 +1,13 @@
+### Restrict resources provisioning to specific regions
+
+This example covers a Gatekeeper policy that denies requests for resources 
+provisioning in any region, except those that are explicitly allowed
+
+Examples and test cases are available under the `samples` directory. 
+Tests can be ran using the [gator cli](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/).
+
+To run tests for this example run:
+```bash
+cd examples/gatekeeper/region-restrict/
+gator verify . -v
+```

--- a/examples/gatekeeper/region-restrict/samples/constraint.yaml
+++ b/examples/gatekeeper/region-restrict/samples/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AwsRegionRestrict
+metadata:
+  name: awsregionrestrict
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["*"]
+  parameters:
+    regions: ["eu-west-1", "eu-west-2"]

--- a/examples/gatekeeper/region-restrict/samples/sample-table-eu-west-2-pass.yaml
+++ b/examples/gatekeeper/region-restrict/samples/sample-table-eu-west-2-pass.yaml
@@ -1,0 +1,23 @@
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: sample-table
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: eu-west-2
+    attributeDefinitions:
+      - attributeName: id
+        attributeType: S
+    keySchema:
+      - attributeName: id
+        keyType: HASH
+    billingMode: PROVISIONED
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+    tags:
+      - key: "owner"
+        value: "finance"
+  providerConfigRef:
+    name: aws-provider-config

--- a/examples/gatekeeper/region-restrict/samples/sample-table-us-east-1-fail.yaml
+++ b/examples/gatekeeper/region-restrict/samples/sample-table-us-east-1-fail.yaml
@@ -1,0 +1,24 @@
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: failing-table
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: us-east-1
+    attributeDefinitions:
+      - attributeName: id
+        attributeType: S
+    keySchema:
+      - attributeName: id
+        keyType: HASH
+    billingMode: PROVISIONED
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+    tags:
+      - key: "owner"
+        value: "finance"
+
+  providerConfigRef:
+    name: aws-provider-config

--- a/examples/gatekeeper/region-restrict/suite.yaml
+++ b/examples/gatekeeper/region-restrict/suite.yaml
@@ -1,0 +1,17 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: awsregionrestrict-suite
+tests:
+- name: awsregionrestrict-suite
+  template: template.yaml
+  constraint: samples/constraint.yaml
+  cases:
+  - name: unauthorised region
+    object: samples/sample-table-us-east-1-fail.yaml
+    assertions:
+    - violations: yes
+  - name: authorised region
+    object: samples/sample-table-eu-west-2-pass.yaml
+    assertions:
+    - violations: no

--- a/examples/gatekeeper/region-restrict/template.yaml
+++ b/examples/gatekeeper/region-restrict/template.yaml
@@ -1,0 +1,30 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: awsregionrestrict
+spec:
+  crd:
+    spec:
+      names:
+        kind: AwsRegionRestrict
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            regions:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package awsregionrestrict
+        
+        import future.keywords
+        
+        violation[{"msg": msg}] {
+            region := input.review.object.spec.forProvider.region
+            not region in input.parameters.regions
+            msg := sprintf("Attempting to provision the resource in '%s', which is not an authorised region. Authorised regions are: '%v'", [region, input.parameters.regions])
+        }

--- a/examples/gatekeeper/required-tags/README.md
+++ b/examples/gatekeeper/required-tags/README.md
@@ -1,0 +1,13 @@
+### Prevent provisioning resources that do not have the required tags
+
+This example covers a Gatekeeper policy that denies requests for provisioning
+resources without the required tags
+
+Examples and test cases are available under the `samples` directory. 
+Tests can be ran using the [gator cli](https://open-policy-agent.github.io/gatekeeper/website/docs/gator/).
+
+To run tests for this example run:
+```bash
+cd examples/gatekeeper/required-tags/
+gator verify . -v
+```

--- a/examples/gatekeeper/required-tags/samples/constraint.yaml
+++ b/examples/gatekeeper/required-tags/samples/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AwsRequiredTags
+metadata:
+  name: awsrequiredtags
+spec:
+  match:
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["*"]
+  parameters:
+    tags: ["owner"]

--- a/examples/gatekeeper/required-tags/samples/dummy-table-missing-tag-fail.yaml
+++ b/examples/gatekeeper/required-tags/samples/dummy-table-missing-tag-fail.yaml
@@ -1,0 +1,23 @@
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: dummy-table
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: eu-west-2
+    attributeDefinitions:
+      - attributeName: id
+        attributeType: S
+    keySchema:
+      - attributeName: id
+        keyType: HASH
+    billingMode: PROVISIONED
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+    tags:
+      - key: "aaa"
+        value: "finance"
+  providerConfigRef:
+    name: aws-provider-config

--- a/examples/gatekeeper/required-tags/samples/dummy-table-no-tags-fail.yaml
+++ b/examples/gatekeeper/required-tags/samples/dummy-table-no-tags-fail.yaml
@@ -1,0 +1,20 @@
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: dummy-table
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: eu-west-2
+    attributeDefinitions:
+      - attributeName: id
+        attributeType: S
+    keySchema:
+      - attributeName: id
+        keyType: HASH
+    billingMode: PROVISIONED
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+  providerConfigRef:
+    name: aws-provider-config

--- a/examples/gatekeeper/required-tags/samples/finance-table-pass.yaml
+++ b/examples/gatekeeper/required-tags/samples/finance-table-pass.yaml
@@ -1,0 +1,23 @@
+apiVersion: dynamodb.aws.crossplane.io/v1alpha1
+kind: Table
+metadata:
+  name: finance-table
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    region: eu-west-2
+    attributeDefinitions:
+      - attributeName: id
+        attributeType: S
+    keySchema:
+      - attributeName: id
+        keyType: HASH
+    billingMode: PROVISIONED
+    provisionedThroughput:
+      readCapacityUnits: 1
+      writeCapacityUnits: 1
+    tags:
+      - key: "owner"
+        value: "finance"
+  providerConfigRef:
+    name: aws-provider-config

--- a/examples/gatekeeper/required-tags/suite.yaml
+++ b/examples/gatekeeper/required-tags/suite.yaml
@@ -1,0 +1,21 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: awsrequiredtags-suite
+tests:
+- name: awsrequiredtags-suite
+  template: template.yaml
+  constraint: samples/constraint.yaml
+  cases:
+  - name: table with no tags
+    object: samples/dummy-table-no-tags-fail.yaml
+    assertions:
+    - violations: yes
+  - name: table with missing tags
+    object: samples/dummy-table-missing-tag-fail.yaml
+    assertions:
+    - violations: yes
+  - name: table with required tags
+    object: samples/finance-table-pass.yaml
+    assertions:
+    - violations: no

--- a/examples/gatekeeper/required-tags/template.yaml
+++ b/examples/gatekeeper/required-tags/template.yaml
@@ -1,0 +1,38 @@
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: awsrequiredtags
+spec:
+  crd:
+    spec:
+      names:
+        kind: AwsRequiredTags
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
+          properties:
+            tags:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package awsrequiredtags
+        import future.keywords.every
+        
+        violation[{"msg": msg}] {
+          endswith(input.review.kind.group, "aws.crossplane.io")
+          not startswith(input.review.kind.kind, "ProviderConfig")
+          not input.review.object.spec.forProvider.tags
+          msg := sprintf("Attempting to provision a resource without tags, the following tags are required '%v'", [input.parameters.tags])
+        }
+
+        violation[{"msg": msg}] {
+          some requested_tag in input.parameters.tags
+          every i in input.review.object.spec.forProvider.tags {
+              requested_tag != i.key
+          }
+          msg := sprintf("Attempting to provision a resource with the following tags '%v', one or more of the required tags '%v' is missing", [input.review.object.spec.forProvider.tags, input.parameters.tags])
+        }


### PR DESCRIPTION
### What does this PR do?

Add two gatekeeper polices - one for restricting AWS regions that resources can be provisioned into, and the other is for preventing provisioning resources without the required tags.

### Motivation
Use the two new policies for creating labs on using Gatekeeper with Crossplane.

### More

- [ X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
