### PR TITLE
Fix S3 BucketPublicAccessBlock configuration under spec.forProvider

### DIFF
--- a/compositions/upbound-aws-provider/s3/general-purpose.yaml
+++ b/compositions/upbound-aws-provider/s3/general-purpose.yaml
@@ -76,13 +76,13 @@ spec:
         kind: BucketPublicAccessBlock
         spec:
           deletionPolicy: Delete
-          blockPublicAcls: true
-          blockPublicPolicy: true
-          ignorePublicAcls: true
-          restrictPublicBuckets: true
           forProvider:
             bucketSelector:
               matchControllerRef: true
+            blockPublicAcls: true
+            blockPublicPolicy: true
+            ignorePublicAcls: true
+            restrictPublicBuckets: true
       patches:
         - fromFieldPath: spec.resourceConfig.region
           toFieldPath: spec.forProvider.region


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `BucketPublicAccessBlock` resource by moving the access configuration from `spec` to `spec.forProvider` as is expected from the CRD.

### Motivation

We use the S3 composition in our workflow and felt that it is beneficial to the community to contribute this fix rather than applying a local patch.

### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
