### PR TITLE
Adding Double Quotes on enum types in dynamodb definition so they are…

### DIFF
--- a/compositions/upbound-aws-provider/dynamodb/definition.yaml
+++ b/compositions/upbound-aws-provider/dynamodb/definition.yaml
@@ -59,9 +59,9 @@ spec:
                             type: string
                           type:
                             enum:
-                            - B #binary
-                            - N #number
-                            - S #string
+                            - "B" #binary
+                            - "N" #number
+                            - "S" #string
                             type: string
                         required:
                         - name


### PR DESCRIPTION
… not interpreted as boolean


### What does this PR do?

<!-- This PR fixes an issue where one of the enum string value is interted as boolean instead of string due to a missing double quote. The issue is related to the second enum (N) but I have changed all 3 items to be uniform.-->


### Motivation

<!-- We use the Dynamodb composition in our environment and this composition will not work unless this change is done therefore felt that it is beneficial to the community to contribute this fix rather than applying a local patch. -->


### More

- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
