### PR TITLE
Fix: github pages build

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,7 +37,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install mkdocs-material==9.5.21 \
             mkdocs-include-markdown-plugin==6.0.6 \
-            mkdocs-awesome-pages-plugin==2.9.2
+            mkdocs-awesome-pages-plugin==2.9.2\
+            mkdocs-glightbox==0.1.0 \
+            mkdocs-minify-plugin==0.8.0 \
+            mkdocs-material-extensions==1.3.1 \
+            pillow==10.3.0 \ 
+            cairosvg==2.7.1 
 
       - name: git config
         run: |

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,13 +37,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install mkdocs-material==9.5.21 \
             mkdocs-include-markdown-plugin==6.0.6 \
-            mkdocs-awesome-pages-plugin==2.9.2\
+            mkdocs-awesome-pages-plugin==2.9.2 \
             mkdocs-glightbox==0.1.0 \
             mkdocs-minify-plugin==0.8.0 \
             mkdocs-material-extensions==1.3.1 \
-            pillow==10.3.0 \ 
-            cairosvg==2.7.1 
-
+            pillow==10.3.0 \
+            cairosvg==2.7.1
+        
       - name: git config
         run: |
           git config --local user.email "action@github.com"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ kubeconfig_*
 *.tfplan
 
 cluster-keys.json
+
+.vscode

--- a/bootstrap/terraform/values/prometheus.yaml
+++ b/bootstrap/terraform/values/prometheus.yaml
@@ -11,6 +11,13 @@ prometheus:
       podMetricsEndpoints:
         - port: "metrics"
       selector: {}
+    - name: "argocd"
+      namespaceSelector:
+        matchNames:
+          - "argocd"
+      podMetricsEndpoints:
+        - port: "metrics"
+      selector: {}
 grafana:
   service:
     type: "LoadBalancer"

--- a/bootstrap/terraform/values/prometheus.yaml
+++ b/bootstrap/terraform/values/prometheus.yaml
@@ -11,13 +11,16 @@ prometheus:
       podMetricsEndpoints:
         - port: "metrics"
       selector: {}
+  additionalServiceMonitors:
     - name: "argocd"
       namespaceSelector:
         matchNames:
           - "argocd"
-      podMetricsEndpoints:
+      endpoints:
         - port: "metrics"
-      selector: {}
+      selector:
+        matchLabels:
+          prometheus.io/scrape: "true"
 grafana:
   service:
     type: "LoadBalancer"

--- a/bootstrap/terraform/values/prometheus.yaml
+++ b/bootstrap/terraform/values/prometheus.yaml
@@ -56,3 +56,11 @@ grafana:
         gnetId: 14584
         revision: 1
         datasource: prometheusdatasource
+      eks:
+        gnetId: 14623
+        revision: 1
+        datasource: prometheusdatasource
+      ekscontrolplane:
+        gnetId: 21192
+        revision: 1
+        datasource: prometheusdatasource

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,5 @@
+nav:
+  - Overview: index.md
+  - Getting Started: getting-started.md
+  - Patterns: patterns
+  - FAQ: faq.md

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,5 +1,0 @@
-nav:
-  - Overview: ../README.md
-  - Getting Started: getting-started.md
-  - Patterns: patterns
-  - FAQ: faq.md

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,5 +1,5 @@
 nav:
-  - Overview: index.md
+  - Overview: ../README.md
   - Getting Started: getting-started.md
   - Patterns: patterns
   - FAQ: faq.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Ensure that you have installed the following tools locally:
 
 ### terraform
 
-1. For consuming Crossplane Blueprints, please see the [Getting Started](https://edgarsilva948.github.io/crossplane-on-eks/getting-started/) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
+1. For consuming Crossplane Blueprints, please see the [Getting Started](https://awslabs.github.io/crossplane-on-eks/getting-started/) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
 
 2. To provision the pattern, the typical steps of execution are as follows:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,9 +18,7 @@ Ensure that you have installed the following tools locally:
 
 ### terraform
 
-1. For consuming Crossplane Blueprints, please see the [Getting Started](https://awslabs.github.io/crossplane-on-eks/#getting-started) section. For exploring and trying out the patterns provided, please
-clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern
-directory of your choice.
+1. For consuming Crossplane Blueprints, please see the [Getting Started](https://awslabs.github.io/crossplane-on-eks/#getting-started) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
 
 2. To provision the pattern, the typical steps of execution are as follows:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Ensure that you have installed the following tools locally:
 
 ### terraform
 
-1. For consuming Crossplane Blueprints, please see the [Getting Started](https://awslabs.github.io/crossplane-on-eks/#getting-started) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
+1. For consuming Crossplane Blueprints, please see the [Getting Started](https://github.com/awslabs/crossplane-on-eks/blob/main/README.md) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
 
 2. To provision the pattern, the typical steps of execution are as follows:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Ensure that you have installed the following tools locally:
 
 ### terraform
 
-1. For consuming Crossplane Blueprints, please see the [Getting Started](https://github.com/awslabs/crossplane-on-eks/blob/main/README.md) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
+1. For consuming Crossplane Blueprints, please see the [Getting Started](https://edgarsilva948.github.io/crossplane-on-eks/getting-started/) section. For exploring and trying out the patterns provided, please clone the project locally to quickly get up and running with a pattern. After cloning the project locally, `cd` into the pattern directory of your choice.
 
 2. To provision the pattern, the typical steps of execution are as follows:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+{%
+   include-markdown "../README.md"
+%}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,0 @@
-{%
-   include-markdown "../README.md"
-%}

--- a/docs/patterns/vault-integration.md
+++ b/docs/patterns/vault-integration.md
@@ -125,8 +125,10 @@ vault write auth/kubernetes/role/crossplane \
 For our test cases to work, we need to configure additional Vault policy and role. Run the following commands in your vault pod or VM.
 
 ```bash
+# {% raw %}
 # create policy and role for applications to use.
 ACCESSOR=$(vault auth list | grep kubernetes | tr -s ' ' | cut -d ' ' -f3)
+
 vault policy write k8s-application - << EOF
 path "secret/data/crossplane-system/{{identity.entity.aliases.${ACCESSOR}.metadata.service_account_namespace}}/*" {
   capabilities = ["read", "list"]
@@ -135,11 +137,14 @@ path "secret/metadata/crossplane-system/{{identity.entity.aliases.${ACCESSOR}.me
   capabilities = ["read", "list"]
 }
 EOF
+
 vault write auth/kubernetes/role/k8s-application \
     bound_service_account_names="*" \
     bound_service_account_namespaces="*" \
     policies=k8s-application \
     ttl=1h
+    
+# {% endraw %}
 ```
 
 ## Install and configure Crossplane

--- a/docs/patterns/vault-integration.md
+++ b/docs/patterns/vault-integration.md
@@ -127,7 +127,6 @@ For our test cases to work, we need to configure additional Vault policy and rol
 ```bash
 # create policy and role for applications to use.
 ACCESSOR=$(vault auth list | grep kubernetes | tr -s ' ' | cut -d ' ' -f3)
-
 vault policy write k8s-application - << EOF
 path "secret/data/crossplane-system/{{identity.entity.aliases.${ACCESSOR}.metadata.service_account_namespace}}/*" {
   capabilities = ["read", "list"]
@@ -136,7 +135,6 @@ path "secret/metadata/crossplane-system/{{identity.entity.aliases.${ACCESSOR}.me
   capabilities = ["read", "list"]
 }
 EOF
-
 vault write auth/kubernetes/role/k8s-application \
     bound_service_account_names="*" \
     bound_service_account_namespaces="*" \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Amazon Crossplane Blueprints
-docs_dir: docs/
+docs_dir: docs
 copyright: Copyright &copy; Amazon 2024
 site_author: AWS
 site_url: https://awslabs.github.io/crossplane-on-eks/
@@ -13,8 +13,20 @@ theme:
   font:
     text: ember
   palette:
-    primary: orange
-    accent: orange
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+      primary: orange
+      accent: orange
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+      primary: orange
+      accent: orange
   icon:
     repo: fontawesome/brands/github
     admonition:
@@ -31,13 +43,32 @@ theme:
       example: octicons/beaker-16
       quote: octicons/quote-16
   features:
+    - header.autohide
     - navigation.tabs.sticky
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.share
+    - search.suggest
+    - content.code.annotate
+    - content.tooltips
+    - content.tabs.link
+    - content.code.copy
   highlightjs: true
   hljs_languages:
     - yaml
     - json
+    - bash
 
 plugins:
+  - glightbox
+  - minify:
+      minify_html: true
+  - social:
+      cards: true
+      cards_layout_options:
+        font_family: Roboto
   - include-markdown
   - search:
       lang:
@@ -47,6 +78,9 @@ plugins:
 extra:
   version:
     provider: mike
+  social:
+    - icon: fontawesome/brands/github-alt
+      link: https://github.com/awslabs/crossplane-on-eks
 
 markdown_extensions:
   - attr_list
@@ -63,5 +97,19 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - toc:
       permalink: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+
+extra_javascript:
+  - https://cdn.jsdelivr.net/npm/@glidejs/glide
+
+nav:
+  - Overview: ../README.md
+  - Getting Started: getting-started.md
+  - Patterns: patterns
+  - FAQ: faq.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,9 +107,3 @@ markdown_extensions:
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/@glidejs/glide
-
-nav:
-  - Overview: ../README.md
-  - Getting Started: getting-started.md
-  - Patterns: patterns
-  - FAQ: faq.md


### PR DESCRIPTION
### What does this PR do?

This PR fixes the existing issues with the GitHub Pages build process. it also introduces a new feature that allows users to switch between light and dark modes, enhancing UX of the doc.

here's my forked repo working: https://edgarsilva948.github.io/crossplane-on-eks/

we need to adjust the Repository -> Settings -> Pages to be:

<img width="810" alt="image" src="https://github.com/awslabs/crossplane-on-eks/assets/17487038/95d88be8-bef1-4671-a840-0ea119b282b6">

### More

- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [X] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes
N/A
