### PR TITLE
fix: changing the helm provider defaults to true

### DIFF
--- a/bootstrap/terraform/variables.tf
+++ b/bootstrap/terraform/variables.tf
@@ -46,5 +46,5 @@ variable "enable_kubernetes_provider" {
 variable "enable_helm_provider" {
   type        = bool
   description = "Installs the helm provider"
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
### What does this PR do?

the default value for the helm provider should be true in the bootstrap


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)

- [ ] Yes, I have added a new example under [examples](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/examples) to support my PR

- [ ] Yes, I have updated the [docs](https://github.com/aws-samples/crossplane-aws-blueprints/tree/main/doc) for this feature

- [ ] Yes, I have linked to an issue or feature request (applicable to PRs that solves a bug or a feature request)

**Note**:
 - Not all the PRs require examples and docs
 - We prefer small, well tested pull requests. Please ensure your pull requests are self-contained, and commits are squashed

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
